### PR TITLE
Improve REST error messages

### DIFF
--- a/lib/zuora/rest/client.rb
+++ b/lib/zuora/rest/client.rb
@@ -89,7 +89,19 @@ module Zuora
       # @return [Faraday::Response]
       def fail_or_response(response)
         success = response.body['success'] && response.status == 200
-        fail(ErrorResponse.new('Non-200', response)) unless success
+        if response.status != 200
+          fail(ErrorResponse.new("HTTP Status #{response.status}", response))
+        elsif !response.body['success']
+          error = "Not successful."
+
+          if response.body["reasons"]
+            error += " " + response.body["reasons"].map do |reason|
+              "Error #{reason["code"]}: #{reason["message"]}"
+            end.join(", ")
+          end
+
+          fail(ErrorResponse.new(error, response))
+        end
         response
       end
 

--- a/lib/zuora/rest/client.rb
+++ b/lib/zuora/rest/client.rb
@@ -95,9 +95,10 @@ module Zuora
           error = "Not successful."
 
           if response.body["reasons"]
-            error += " " + response.body["reasons"].map do |reason|
+            reasons = response.body["reasons"].map do |reason|
               "Error #{reason["code"]}: #{reason["message"]}"
-            end.join(", ")
+            end
+            errors += " " + reasons.join(", ")
           end
 
           fail(ErrorResponse.new(error, response))

--- a/spec/cassettes/rest/get_account_500_error.yml
+++ b/spec/cassettes/rest/get_account_500_error.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://apisandbox-api.zuora.com/rest/v1/accounts/2c92c0fa52e3f6790152f11fd4fd1fcf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Cookie:
+      - ZSession=RmeipYqHIQQTnou14G0bP-HRT3xh84qud42RZYPoI3AK59Ei_9B7oh-mtrdop4PxG6VyQutkHee1cbnQLgKDLNISqM61gxGH6AxM2XVihZSwUfREDk0tPJzVUX_2MN6j1xYDMgaRvFeDgI_Zcol4dWZ-FDCEeGyzU9rl7Hb3pVZuzCsgr8K9lweg79653CPuRY8QTFZ-G7NRO4jJTdJPvfQxWtFWctAjsmXuwLhmxWPwdMplmAaP5ILEUWKG8phL;
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Error
+    headers:
+      Server:
+      - Zuora App
+      Content-Type:
+      - text/plain
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 17 Feb 2016 21:43:07 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        We're sorry, but something went wrong.
+    http_version: 
+  recorded_at: Wed, 17 Feb 2016 21:43:07 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/rest/get_account_with_error.yml
+++ b/spec/cassettes/rest/get_account_with_error.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://apisandbox-api.zuora.com/rest/v1/accounts/2c92c0fa52e3f6790152f11fd4fd1fcfx
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Cookie:
+      - ZSession=RmeipYqHIQQTnou14G0bP-HRT3xh84qud42RZYPoI3AK59Ei_9B7oh-mtrdop4PxG6VyQutkHee1cbnQLgKDLNISqM61gxGH6AxM2XVihZSwUfREDk0tPJzVUX_2MN6j1xYDMgaRvFeDgI_Zcol4dWZ-FDCEeGyzU9rl7Hb3pVZuzCsgr8K9lweg79653CPuRY8QTFZ-G7NRO4jJTdJPvfQxWtFWctAjsmXuwLhmxWPwdMplmAaP5ILEUWKG8phL;
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Zuora App
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '1669'
+      Expires:
+      - Wed, 17 Feb 2016 21:43:07 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 17 Feb 2016 21:43:07 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - ZSession=DXFs9gwav5sA7yMxV1yd5FNUP4N-_S3gWV8-GWYpcKYWh--Z5cAS8S8yuuHqrPhEl5uN6fA1DXmFib9zdsdHhNfUR7zf1yULKh6dkJAF90pqxvkuaKL49WqPqQnMjIDRDyQAaPXJfQvA63qcpe9_2k9ouuZRbgC_sExCKLyRJqT_TRkzv1GUsb5LTt-tUMQrq9Wv4Kyem-3bujb_Ts26M25lCz7omNHKILtjb82WZNCvzQ5lzRyiqtXHyUWzPAL8;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "success": false,
+          "processId": "9E8786DEB80E2331",
+          "reasons": [
+            {
+              "code": 50000040,
+              "message": "Cannot find entity by key: '2c92c0fa52e3f6790152f11fd4fd1fcfx'."
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Wed, 04 Jan 2017 04:25:07 GMT
+recorded_with: VCR 3.0.1
+

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -97,6 +97,28 @@ describe Zuora::Rest::Client do
 
       describe 'GET' do
         it { expect { get_account }.to_not raise_error }
+
+        it "should raise a human-readable exception when an error happens" do
+	  VCR.use_cassette('rest/get_account_with_error') do
+	    expect {
+	      client.get "/rest/v1/accounts/#{account_id}x"
+	    }.to raise_error(
+              Zuora::Rest::ErrorResponse,
+              "Not successful. Error 50000040: Cannot find entity by key: '2c92c0fa52e3f6790152f11fd4fd1fcfx'."
+            )
+	  end
+	end
+
+        it "should raise a an error with the HTTP status during an outage" do
+	  VCR.use_cassette('rest/get_account_500_error') do
+	    expect {
+	      client.get "/rest/v1/accounts/#{account_id}"
+	    }.to raise_error(
+              Zuora::Rest::ErrorResponse,
+              "HTTP Status 500"
+            )
+	  end
+	end
       end
 
       describe 'DELETE' do


### PR DESCRIPTION
This commit changes the messages shown in Zuora::Rest::ErrorResponse to
distinguish between HTTP error codes and Zuora application errors, and also
includes Zuora's error reasons in the exception's message when they are
available.

@github/gitcoin 